### PR TITLE
Reimplement using ManuallyDrop instead of Option.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discard"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Pauan <pcxunlimited@gmail.com>"]
 description = "Discard trait which allows for intentionally leaking memory"
 repository = "https://github.com/Pauan/rust-discard"


### PR DESCRIPTION
It's possible to implement this (with the use of a bit of unsafe code) using no run-time overhead, by using the Rust standard library's `ManuallyDrop` instead of `Option`. That's what this PR does.